### PR TITLE
oss: Add CircleCI build coverage for Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,15 +155,21 @@ jobs:
           with_cache: false
       - rust/build:
           with_cache: false
+      - run:
+          name: Build buck2 binary
+          command: |
+            mkdir C:/tmp/artifacts
+            cargo build --bin=buck2 --release -Z unstable-options --out-dir=C:/tmp/artifacts
+      - run:
+          name: Setup and build example/prelude directory
+          command: |
+            cd examples/prelude
+            cmd.exe /c mklink /D prelude C:\Users\circleci\project\prelude
+            C:/tmp/artifacts/buck2.exe build //...
       - when:
           condition:
             *is_main_branch
           steps:
-          - run:
-              name: Build buck2 binary to upload
-              command: |
-                mkdir C:/tmp/artifacts
-                cargo build --bin=buck2 --release -Z unstable-options --out-dir=C:/tmp/artifacts
           - store_artifacts:
               path: C:/tmp/artifacts/buck2.exe
               destination: buck2-windows.exe

--- a/examples/prelude/cpp/hello_world/BUILD
+++ b/examples/prelude/cpp/hello_world/BUILD
@@ -6,10 +6,10 @@ cxx_binary(
     link_style = "static",
     srcs = ["main.cpp"],
     deps = ["//cpp/library:print"]
-)
+) if not host_info().os.is_windows else None
 
 assert_output(
     name = "check_main",
     command = "$(exe_target :main)",
     output = "hello world from cpp toolchain",
-)
+) if not host_info().os.is_windows else None

--- a/examples/prelude/cpp/library/BUILD
+++ b/examples/prelude/cpp/library/BUILD
@@ -5,4 +5,4 @@ cxx_library(
     srcs = glob(["**/*.cpp"]),
     exported_headers = glob(["**/*.hpp"]),
     visibility = ["PUBLIC"],
-)
+) if not host_info().os.is_windows else None

--- a/examples/prelude/cpp/python_cextension/BUILD
+++ b/examples/prelude/cpp/python_cextension/BUILD
@@ -18,4 +18,4 @@ cxx_library(
         "-isystem{}".format("/usr/include/python3.10"),
     ],
     visibility = ["PUBLIC"],
-)
+) if not host_info().os.is_windows else None

--- a/examples/prelude/ocaml/hello_world/BUILD
+++ b/examples/prelude/ocaml/hello_world/BUILD
@@ -5,10 +5,10 @@ ocaml_binary(
     name = "main",
     srcs = ["main.ml"],
     deps = ["//ocaml/library:print"]
-)
+) if not host_info().os.is_windows else None
 
 assert_output(
     name = "check_main",
     command = "$(exe_target :main)",
     output = "hello world from ocaml toolchain",
-)
+)if not host_info().os.is_windows else None

--- a/examples/prelude/ocaml/library/BUILD
+++ b/examples/prelude/ocaml/library/BUILD
@@ -4,4 +4,4 @@ ocaml_library(
     name = "print",
     srcs = ["library.ml"],
     visibility = ["PUBLIC"],
-)
+) if not host_info().os.is_windows else None

--- a/examples/prelude/test_utils.bzl
+++ b/examples/prelude/test_utils.bzl
@@ -1,6 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under both the MIT license found in the
+# LICENSE-MIT file in the root directory of this source tree and the Apache
+# License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+# of this source tree.
+
 def assert_output(name, command, output):
     return native.genrule(
         name = name,
         bash = command + " | grep \"" + output + "\" && touch \"$OUT\"",
+        cmd_exe = command + " | findstr \"" + output + "\" && type nul > \"$OUT\"",
         out = "out.txt",
     )


### PR DESCRIPTION
Summary: Add build coverage for examples/prelude/... for Windows as well. Most targets (ocaml, c++) are currently disabled for Windows for now. As I try to expand the examples to add rust and fix c++ for Windows, this will help me iterate a bit faster.

Differential Revision: D42068240

