### PR TITLE
oss: Add a basic Rust example

### DIFF
--- a/examples/prelude/cpp/library/BUILD
+++ b/examples/prelude/cpp/library/BUILD
@@ -1,5 +1,3 @@
-load("@prelude//rules.bzl", "cxx_library")
-
 cxx_library(
     name = "print",
     srcs = glob(["**/*.cpp"]),

--- a/examples/prelude/cpp/python_cextension/BUILD
+++ b/examples/prelude/cpp/python_cextension/BUILD
@@ -1,5 +1,3 @@
-load("@prelude//rules.bzl", "cxx_python_extension")
-
 # cxx_python_extension(
 #     name = "cpprint",
 #     srcs = ["print.cpp"],

--- a/examples/prelude/python/hello_world/BUILD
+++ b/examples/prelude/python/hello_world/BUILD
@@ -1,4 +1,3 @@
-load("@prelude//rules.bzl", "python_binary")
 load("//test_utils.bzl", "assert_output")
 
 python_binary(

--- a/examples/prelude/python/library/BUILD
+++ b/examples/prelude/python/library/BUILD
@@ -1,5 +1,3 @@
-load("@prelude//rules.bzl", "python_library")
-
 python_library(
     name = "printlib",
     srcs = ["print.py"],

--- a/examples/prelude/python/use_cextension/BUILD
+++ b/examples/prelude/python/use_cextension/BUILD
@@ -1,5 +1,3 @@
-load("@prelude//rules.bzl", "python_binary")
-
 # FIXME(marwhal): Get python_cextension example working again
 # python_binary(
 #     name = "cext",

--- a/examples/prelude/rust/BUILD
+++ b/examples/prelude/rust/BUILD
@@ -1,14 +1,15 @@
 load("//test_utils.bzl", "assert_output")
 
-cxx_binary(
+rust_binary(
     name = "main",
-    link_style = "static",
-    srcs = ["main.cpp"],
-    deps = ["//cpp/library:print"]
+    srcs = glob(
+        ["src/**/*.rs"],
+    ),
+    crate_root = "src/main.rs",
 ) if not host_info().os.is_windows else None
 
 assert_output(
     name = "check_main",
     command = "$(exe_target :main)",
-    output = "hello world from cpp toolchain",
+    output = "hello world from rust toolchain",
 ) if not host_info().os.is_windows else None

--- a/examples/prelude/rust/src/main.rs
+++ b/examples/prelude/rust/src/main.rs
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+mod print_hello;
+fn main() {
+    print_hello::print_hello();
+}

--- a/examples/prelude/rust/src/print_hello.rs
+++ b/examples/prelude/rust/src/print_hello.rs
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under both the MIT license found in the
+ * LICENSE-MIT file in the root directory of this source tree and the Apache
+ * License, Version 2.0 found in the LICENSE-APACHE file in the root directory
+ * of this source tree.
+ */
+
+pub fn print_hello() {
+    println!("hello world from rust toolchain");
+}

--- a/examples/prelude/toolchains/BUILD
+++ b/examples/prelude/toolchains/BUILD
@@ -1,6 +1,7 @@
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 load("@prelude//toolchains:ocaml.bzl", "system_ocaml_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain", "system_python_toolchain")
+load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 
 system_cxx_toolchain(
     name = "cxx",
@@ -19,5 +20,11 @@ system_python_toolchain(
 
 system_python_bootstrap_toolchain(
     name = "python_bootstrap",
+    visibility = ["PUBLIC"],
+)
+
+system_rust_toolchain(
+    name = "rust",
+    default_edition = "2021",
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
Summary:
Add a basic rust example that works for both mac and linux. (Needs work for windows)

Also remove all the XX_library/XX_binary imports in BUILD files as they are not needed.

Reviewed By: ndmitchell

Differential Revision: D42099018

