### PR TITLE
Improve setup.sh

### DIFF
--- a/examples/prelude/README.md
+++ b/examples/prelude/README.md
@@ -17,9 +17,21 @@ ln -s $(realpath ../../prelude) prelude
 
 If you are using any other prelude directory, make sure the prelude points to it in `.buckconfig`
 
+On Linux and macOS, an alternative to symlinking the prelude manually in this way is to `source setup.sh` (see the next section for details).
+
+## Support for building the example OCaml targets
+
+The information in this section is (at this time) Linux and macOS specific.
+
+The commands in `setup.sh` assume an [opam](https://opam.ocaml.org/) installation.
+
+Some of these commands are intended to affect the current shell thus `setup.sh` is to be invoked via the `source` builtin e.g `source setup.sh`.
+
+In addition to symlinking the prelude directory [as described above](#add-in-prelude-into-the-project), sourcing `setup.sh` activates the 'default' opam switch and creates symlinks in the 'third-party/opam' directory. These symlinks are neccessary to support building the example OCaml targets. If any of the symlinks are found to already exist, they will not be overwritten.
+
 ## Sample commands
 
-**_NOTE:_** These are currently only supported on Linux
+**_NOTE:_** These commands are currently only supported on Linux and macOS.
 
 ```sh
 $BUCK2 build //...

--- a/examples/prelude/setup.sh
+++ b/examples/prelude/setup.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under both the MIT license found in the
@@ -6,18 +5,23 @@
 # License, Version 2.0 found in the LICENSE-APACHE file in the root directory
 # of this source tree.
 
-set -euo pipefail
+# The commands in this script are to be executed in the current shell
+# and so invoke it via the builtin 'source' command e.g. `source
+# setup.sh`. It assumes an opam installation. In addition to
+# symlinking the 'prelude' directory it activates the 'default' opam
+# switch and create symlinks in the 'third-party/opam' directory to
+# support building the example OCaml targets.
 
 CWD="$(pwd)"
 BASENAME="$(basename "$CWD")"
 DIRNAME="$(basename "$(dirname "$CWD")")"
 if [ "$DIRNAME" != "examples" ] && [ "$BASENAME" != "prelude" ]; then
-    echo "$0 should be run from directory 'examples/prelude'"
+    echo "$0 should be sourced from directory 'examples/prelude'"
     exit 1
 fi
 
 # Bring the OCaml toolchain into scope.
-eval "$(opam env --switch=default)"
+eval "$(opam env --switch=default --set-switch)"
 
 # Link 'prelude'.
 if [ ! -L prelude ]; then


### PR DESCRIPTION
Two small improvements:
- remove `set -euo pipefail` from the top of the script since it plays poorly with zsh (and after consideration have reached the conclusion was never correct in that the script is intended to be sourced so "exiting" the shell even in the event of an error is not the right thing to do);
- add `--set-switch` to the `opam env` command in order to silence the notice "`[NOTE] To make opam select the switch default in the current shell, add --set-switch or set OPAMSWITCH`"