### PR TITLE
Add cxx subtargets to native python build

### DIFF
--- a/prelude/python/python_binary.bzl
+++ b/prelude/python/python_binary.bzl
@@ -313,7 +313,7 @@ def convert_python_library_to_executable(
         )
 
         executable_info, _, _ = cxx_executable(ctx, impl_params)
-        extra["native-executable"] = [DefaultInfo(default_outputs = [executable_info.binary])]
+        extra["native-executable"] = [DefaultInfo(default_outputs = [executable_info.binary], sub_targets = executable_info.sub_targets)]
 
         linkable_graph = create_linkable_graph(
             ctx,


### PR DESCRIPTION
Summary: This allows us to access the sub-targets generated for the c++ binary when building

Differential Revision: D42438278

