### PR TITLE
fix missing hidden linker deps

### DIFF
--- a/examples/prelude/ocaml/extend/BUILD
+++ b/examples/prelude/ocaml/extend/BUILD
@@ -1,23 +1,23 @@
 load("//test_utils.bzl", "assert_output")
 
 ocaml_binary(
-    name = "hello",
+    name = "hello-c",
     srcs = [
         "hello.ml",
     ],
-    deps = [":hello-stubs"],
-) if host_info().os.is_linux else None
+    deps = [":hello-stubs-c"],
+) if not host_info().os.is_windows else None
 
 cxx_library(
-    name = "hello-stubs",
+    name = "hello-stubs-c",
     srcs = [
         "hello_stubs.c",
     ],
     deps = ["//third-party/ocaml:ocaml-dev"],
-) if host_info().os.is_linux else None
+) if not host_info().os.is_windows else None
 
 assert_output(
-    name = "check-hello",
-    command = "$(exe_target :hello)",
-    output = "Hello",
-) if host_info().os.is_linux else None
+    name = "check-hello-c",
+    command = "$(exe_target :hello-c)",
+    output = "Hello C",
+) if not host_info().os.is_windows else None

--- a/examples/prelude/ocaml/extend/hello_stubs.c
+++ b/examples/prelude/ocaml/extend/hello_stubs.c
@@ -12,6 +12,6 @@
 
 CAMLprim value caml_print_hello(value unit) {
   (void)unit;
-  printf("Hello\n");
+  printf("Hello C!\n");
   return Val_unit;
 }

--- a/examples/prelude/ocaml/extend/hello_stubs.rs
+++ b/examples/prelude/ocaml/extend/hello_stubs.rs
@@ -1,0 +1,5 @@
+#[no_mangle]
+pub unsafe extern "C" fn caml_print_hello(_: usize) -> usize {
+    println!("Hello Rust!\n");
+    return 0;
+}


### PR DESCRIPTION
discussed in some detail in T141930773. turns out some deps have been missing from linker commands. adding them in resolves the darwin link failures for the `ocaml/extend:hello` example.