### PR TITLE
circleci: Rever macos machine change and reduce number of cpus used to build buck2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
       Build the example project and upload buck2 binary for macOS
     macos:
       xcode: 13.4.1
-    resource_class: macos.x86.metal.gen1
+    resource_class: large 
     steps:
       - checkout
       - setup_macos_env
@@ -141,7 +141,7 @@ jobs:
           name: Build buck2 binary
           command: |
             mkdir /tmp/artifacts
-            cargo build --bin=buck2 --release -Z unstable-options --out-dir=/tmp/artifacts
+            cargo build -j 6 --bin=buck2 --release -Z unstable-options --out-dir=/tmp/artifacts
       - run:
           name: Setup and build example/prelude directory
           command: |


### PR DESCRIPTION
I recently changed the macos build job executor type to macos.x86.metal.gen1 to prevent the `cargo build` job from timing out. I suspected it was from maxing out cpu usage, so I thought using a bigger machine would solve it. Which it did, but since they only provide one of these machines at a time, it led to the jobs queuing up quite a bit. 
(https://circleci.com/docs/configuration-reference/#resourceclass)

Change the class back to large, just use less cpus when building buck2. I think this should work?
