### PR TITLE
circleci: Limit number of CPUs used in Linux cargo test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,10 @@ jobs:
       - setup_linux_env
       - rust/clippy:
           with_cache: false
+      - run:
+          # the xlarge linux resource class has 8 CPUs, limit the number of jobs to 6 to avoid running out of resources
+          name: "Set CARGO_BUILD_JOBS=6 to limit the number of CPUs used"
+          command: echo 'export CARGO_BUILD_JOBS="6"' >> "$BASH_ENV"
       - rust/build:
           with_cache: false
       - rust/test:


### PR DESCRIPTION
The linux-build-and-test keeps failing (not always) with the following error:
```
error: linking with `cc` failed: exit status: 1
  |
  = note: "cc" "-m64" "/tmp/rustcBHQgh0/symbols.o" ... "/home/circleci/project/target/debug/deps/buck2-6f57e2aac7617637" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro,-znow" "-nodefaultlibs"
  = note: collect2: fatal error: ld terminated with signal 9 [Killed]
          compilation terminated
```
See https://app.circleci.com/pipelines/github/facebookincubator/buck2/2762/workflows/7a3b999a-649a-41b5-9063-076331e1a0bd/jobs/7719

