### PR TITLE
handle panic event type in super/simple-console

### DIFF
--- a/app/buck2_client_ctx/src/subscribers/simpleconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/simpleconsole.rs
@@ -297,6 +297,19 @@ where
         Ok(())
     }
 
+    async fn handle_panic(
+        &mut self,
+        panic: &buck2_data::Panic,
+        _event: &BuckEvent,
+    ) -> anyhow::Result<()> {
+        if panic.quiet {
+            return Ok(());
+        }
+        echo!("{}", panic.payload)?;
+        self.notify_printed();
+        Ok(())
+    }
+
     async fn handle_file_watcher_end(
         &mut self,
         file_watcher: &buck2_data::FileWatcherEnd,

--- a/app/buck2_client_ctx/src/subscribers/superconsole.rs
+++ b/app/buck2_client_ctx/src/subscribers/superconsole.rs
@@ -343,6 +343,23 @@ impl UnpackingEventSubscriber for StatefulSuperConsole {
         }
     }
 
+    async fn handle_panic(
+        &mut self,
+        panic: &buck2_data::Panic,
+        event: &BuckEvent,
+    ) -> anyhow::Result<()> {
+        if panic.quiet {
+            return Ok(());
+        }
+        match &mut self.super_console {
+            Some(super_console) => {
+                super_console.emit(panic.payload.lines().map(Line::sanitized).collect());
+                Ok(())
+            }
+            None => self.state.simple_console.handle_panic(panic, event).await,
+        }
+    }
+
     async fn handle_file_watcher_end(
         &mut self,
         file_watcher: &buck2_data::FileWatcherEnd,

--- a/app/buck2_events/src/sink/scribe.rs
+++ b/app/buck2_events/src/sink/scribe.rs
@@ -129,6 +129,7 @@ mod fbcode {
                                     buf.len()),
                                     metadata: metadata::collect(),
                                     backtrace: Vec::new(),
+                                    quiet: false,
                                 }
                                 .into(),
                             ),

--- a/buck2_data/data.proto
+++ b/buck2_data/data.proto
@@ -240,6 +240,9 @@ message Panic {
   map<string, string> metadata = 3;
   // A backtrace associated with this panic.
   repeated StackFrame backtrace = 4;
+  // Panic is also used to propagate soft_errors, which can be hidden from
+  // users. If true, it won't get logged to console
+  bool quiet = 5;
 }
 
 // An event capturing the input, output, and context during the execution of an


### PR DESCRIPTION
Summary: we emit soft_errors as events, so we can handle the logging on the client side as well.

Differential Revision: D43353028

