### PR TITLE
oss: fix circleci macos job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ commands:
             # Avoid: "Error: The `brew link` step did not complete
             # successfully" (for llvm dependency 'six').
             rm -f '/usr/local/lib/python3.9/site-packages/six.py'
+            brew unlink python@3.9
             brew install cmake coreutils opam llvm
       - run:
           name: Init opam


### PR DESCRIPTION
Summary:
CircleCI macos jobs feeling at `brew install` step: https://app.circleci.com/pipelines/github/facebookincubator/buck2/3014/workflows/dba9660e-87c4-4249-8bd5-06980f4007bf/jobs/8465

Error:
```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3
Target /usr/local/bin/2to3
is a symlink belonging to python@3.9. You can unlink it:
  brew unlink python@3.9

To force the link and overwrite all conflicting files:
  brew link --overwrite python@3.11

To list all files that would be deleted:
  brew link --overwrite --dry-run python@3.11

```

Differential Revision: D43395192

